### PR TITLE
test: fix pytest warnings

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sqlmodel import Field, SQLModel
 from redis_om import JsonModel
 from redis_om import get_redis_connection
@@ -58,8 +58,7 @@ class LobbyOutput(BaseModel):
     status: Literal["waiting", "playing", "finishing"] = "waiting"
     player_ids: list[str]
 
-    class Config:
-        extra = "ignore"
+    model_config = ConfigDict(extra="ignore")
 
 
 class Player(BaseJsonModel):

--- a/backend/app/tests/pytest.ini
+++ b/backend/app/tests/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    ignore::pydantic.PydanticDeprecatedSince20:redis_om
+    ignore::pydantic.PydanticDeprecatedSince211:redis_om


### PR DESCRIPTION
### Summary
- Added `pytest.ini` which is configured to filter Pydantic deprecated warnings caused by redis_om
- Fixed usage of deprecated `Config` class in `models.py`